### PR TITLE
Change diff syntax

### DIFF
--- a/docs/math3d.js
+++ b/docs/math3d.js
@@ -366,24 +366,24 @@ class MathUtility {
     
     // This is a parser for converting from mathquill's latex to expressions mathjs can parse.
     static texToMathJS(tex) {
-        tex = fracToDivision(tex);
-        console.log(tex);
-        tex = diffParser(tex);
-        console.log(tex);
-        
-        var expressions = [
+        var replacements = [
+            {tex:'\\operatorname{diff}',math:'diff'},
             {tex: '\\cdot', math: ' * '},
             {tex: '\\left', math: ''},
             {tex: '\\right',math: ''},
             {tex: '{', math: '('},
             {tex: '}', math: ')'},
+            {tex: '~', math:' '},
             {tex: '\\', math: ' '},
-            {tex: '~', math:' '}
         ]
 
-        for (let j = 0; j < expressions.length; j++) {
-            tex = Utility.replaceAll(tex, expressions[j]['tex'], expressions[j]['math'])
+        for (let j = 0; j < replacements.length; j++) {
+            tex = Utility.replaceAll(tex, replacements[j]['tex'], replacements[j]['math'])
         }
+        
+        tex = fracToDivision(tex);
+        tex = diffParser(tex);
+        
         return tex;
         
         function fracToDivision(string){

--- a/docs/math3d.js
+++ b/docs/math3d.js
@@ -292,7 +292,39 @@ class Utility {
     static replaceAll(str, find, replace) {
         return str.replace(new RegExp(Utility.escapeRegExp(find), 'g'), replace);
     }
+    
+    static findClosingBrace(string, startIdx){
+        var braces = {
+            '[':']',
+            '<':'>',
+            '(':')',
+            '{':'}'
+        };
+        var openingBrace = string[startIdx];
+        var closingBrace = braces[openingBrace];
+        
+        if (closingBrace===undefined){
+            throw `${string} does not contain an opening brace at position ${startIdx}.`
+        }
+        
+        var stack = 1;
+        
+        for (let j=startIdx+1; j<string.length; j++){
+            console.log(string[j],closingBrace)
+            if (string[j] === openingBrace){
+                stack += +1;
+            }
+            else if (string[j]==closingBrace){
+                stack += -1;
+                return j;
+            }
+        }
 
+        if (stack !== 0 ){
+            throw `${string} has a brace that opens at position ${startIdx} but does not close.`
+        }
+        
+    }
 }
 
 class MathUtility {
@@ -352,34 +384,13 @@ class MathUtility {
         
         function fracToDivision(string){
             var frac = "\\frac",
-            fracStart = string.indexOf(frac), // numerator start
-            numStart = fracStart + frac.length,
-            divIndex,
-            stack;
-    
-            if (fracStart < 0){ return string; }
-    
-            stack = 1;
-
-            for (let j=numStart+1; j<string.length; j++){
-                if (string[j] === "{"){
-                    stack += +1;
-                }
-                else if (string[j]=="}"){
-                    stack += -1;
-                }
-                if (stack===0) {
-                    divIndex = j;
-                    break;
-                }
-            }
-    
-            if (stack !== 0 ){
-                throw `${string} has an unmatched fraction starting at position ${fracStart}`
-            }
+            fracStart = string.indexOf(frac), 
+            numStart = fracStart + frac.length; // numerator start
+            
+            var divIdx = Utility.findClosingBrace(string,numStart)
     
             // Remove frac, and add "/"
-            string = string.slice(0,fracStart) + string.slice(numStart,divIndex+1) + "/" + string.slice(divIndex+1);
+            string = string.slice(0,fracStart) + string.slice(numStart,divIdx+1) + "/" + string.slice(divIdx+1);
 
             // Test if any fracs remain
             fracStart = string.indexOf(frac)


### PR DESCRIPTION
This PR enables the more function-oriented syntax for derivatives. Now MathExpression.parse() will automatically make conversions like:

`diff(f)(t) ---> diff(f,t)`

`diff(diff(r2))(u,v) --> diff(diff(r2),u,v)`