### PR TITLE
Refactor math3d constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,8 +102,8 @@
               </ul>
             </div>
             <div ui-tree="treeOptions" id='tree-root' ng-controller="treeCtrl">
-              <div class="list-group" ui-tree-nodes ng-model="mathTree">
-                <div class="list-group-item" ui-tree-node ng-repeat="branch in mathTree" data-collapsed="branch.collapsed">
+              <div class="list-group" ui-tree-nodes ng-model="math3d.mathTree">
+                <div class="list-group-item" ui-tree-node ng-repeat="branch in math3d.mathTree" data-collapsed="branch.collapsed">
                   <div ng-include="'resources/templates/folder.html'">
                   </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -173,7 +173,6 @@ var queryString = Utility.getQueryString();
 var encodedUserSettings = queryString['settings'];
 
 var authorSettings = {
-  containerId:'my-math-box',
   wrappedMathTree:[
     {
       name:'Folder 1',
@@ -216,7 +215,8 @@ var authorSettings = {
 
 var settings = encodedUserSettings===undefined ? authorSettings : Math3D.decodeSettingsAsURL64(encodedUserSettings);
 
-var math3d = new Math3D(settings);
+var math3d = new Math3D('my-math-box');
+math3d.load(settings)
 
 </script>
 

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -445,6 +445,19 @@ class Math3D {
         this.renderMathObjects();
     }
     
+    clear(){
+        // Remove objects before re-assigning mathTree. I'm not entirely sure if this is necessary.
+        _.forEach(this.mathTree, function(branch, idx) {
+            var branchLength = branch.objects.length; // each iteration of loop changes branch.objects.length, so store it at beginning.
+            for (let j=0; j<branchLength; j++){
+                branch.objects[0].remove();
+            }
+        });
+        this.mathTree = [];
+        // wipe mathbox
+        this.mathbox.remove('*');
+    }
+    
     setCamera(){
         // setup camera
         this.mathbox.camera({

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -23,27 +23,12 @@
 'use strict';
 
 class Math3D {
-    constructor(settings) {
-        this.swizzleOrder = Utility.defaultVal(settings.swizzleOrder, 'yzx');
-        this.settings = this.setDefaults(settings);
-
+    constructor(containerId, settings) {
         this.mathbox = this.initializeMathBox();
-        this.scene = this.setupScene();
-        this.updateRange();
-
-        // Initial Drawing
-        this.drawAxes();
-        this.drawGrids();
-
-        // Add getters and setters for updating after initial rendering
-        this.settings = this.makeDynamicSettings();
-
-        // create mathScope and toggleScope
-        this.mathTree = [] //onVariableChange checks mathTree, so define it as empty for now.
-        this.setDefaultScopes();
         
-        //Render math objects; this will update this.mathTree
-        this.renderMathObjects();
+        if (settings !== undefined){
+            this.load(settings)
+        }
     }
 
     setDefaultScopes() {
@@ -410,17 +395,15 @@ class Math3D {
         }
     }
 
-    initializeMathBox() {
-        var settings = this.settings
-
+    initializeMathBox(containerId) {
         // if necessary, add a container for mathbox
-        if ($("#" + settings.containerId).length === 0) {
-            settings.containerId = _.uniqueId();
+        if ($("#" + containerId).length === 0) {
+            containerId = _.uniqueId();
             this.container = $("<div class='mathbox-container'></div>");
-            this.container.attr('id', settings.containerId);
+            this.container.attr('id', containerId);
             $('body').append(this.container);
         } else {
-            this.container = $("#" + settings.containerId)
+            this.container = $("#" + containerId)
             this.container.addClass('mathbox-container');
         }
 
@@ -433,15 +416,41 @@ class Math3D {
             controls: controls,
             element: this.container[0]
         });
-
-        // setup camera
-        mathbox.camera({
-            proxy: true,
-            position: this.swizzle(settings.camera.position),
-        });
+        
         mathbox.three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
         return mathbox;
+    }
+    
+    load(settings){
+        this.swizzleOrder = Utility.defaultVal(settings.swizzleOrder, 'yzx');
+        this.settings = this.setDefaults(settings);
+        
+        this.setCamera();
+        this.scene = this.setupScene();
+        this.updateRange();
+
+        // Initial Drawing
+        this.drawAxes();
+        this.drawGrids();
+
+        // Add getters and setters for updating after initial rendering
+        this.settings = this.makeDynamicSettings();
+
+        // create mathScope and toggleScope
+        this.mathTree = [] //onVariableChange checks mathTree, so define it as empty for now.
+        this.setDefaultScopes();
+        
+        //Render math objects; this will update this.mathTree
+        this.renderMathObjects();
+    }
+    
+    setCamera(){
+        // setup camera
+        this.mathbox.camera({
+            proxy: true,
+            position: this.swizzle(this.settings.camera.position),
+        });
     }
 
     setupScene() {

--- a/resources/math3d_app.js
+++ b/resources/math3d_app.js
@@ -180,7 +180,7 @@ app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {
     }
     
     $scope.createNewFolder = function(){
-        $scope.mathTree.push({name:'Untitled', objects:[], collapsed:false});
+        $scope.math3d.mathTree.push({name:'Untitled', objects:[], collapsed:false});
     }
     
     $scope.addOjbectToUi = function(obj){

--- a/resources/math3d_app.js
+++ b/resources/math3d_app.js
@@ -172,7 +172,7 @@ app.controller('axesSettingsCtrl', ['$scope', function($scope){
 app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {    
     $scope.debug = arg => console.log(arg);
     
-    $scope.mathTree = math3d.mathTree;
+    $scope.math3d = math3d;
     
     $scope.createNewObject = function(type){
         var metaMathObj = {type:type, settings:{}};

--- a/resources/templates/folder.html
+++ b/resources/templates/folder.html
@@ -19,7 +19,7 @@
         <textarea rows="1" style="width:{{branch.name.length+2}}ch;" class="object-description form-control input-quiet input-xs" type='text' ng-model="branch.name"> </textarea>
       </div>
       <div class="folder-header-right pull-right">
-        <a class="pull-right btn btn-link btn-xs btn-quiet" data-nodrag ng-class="{disabled: branch.objects.length>0 || mathTree.length === 1}" ng-click="removeFolder(branch);">
+        <a class="pull-right btn btn-link btn-xs btn-quiet" data-nodrag ng-class="{disabled: branch.objects.length>0 || math3d.mathTree.length === 1}" ng-click="removeFolder(branch);">
           <span class="glyphicon glyphicon-remove">
           </span>
         </a>


### PR DESCRIPTION
This is a slight refactoring of the math3d constructor in order to allow reloading a different math3d scene without reloading the entire page.

OLD usage:
```
settings = {
  containerId = 'math3d-container',
  // other settings
}
math3d = new Math3D(settings)
```

NEW usage:
```
settings1 = {
  // other settings
}
settings2 = {
  // different settings
}
math3d = new Math3D('math3d-container')
math3d.load(settings1)
math3d.clear()
math3d.load(settings2)
```

`math3d.clear()` and a subsequent `math3d.load()` only affect the math3d object and the rendered scene. **The UI is not automatically updated**. To force the UI to update, do a `$scope.$apply()`.