### PR TITLE
Some refactoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@ var authorSettings = {
       objects: [
         {
           type: 'Point',
-          settings: {rawExpression: "[1,2,sqrt(9)]"}
+          settings: {rawExpression: "[1,sqrt(4),3]"}
         },
         {
           type: 'Vector',

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -883,8 +883,6 @@ class MathObject {
         
         // Record all MathQuill mathfields associated with with this object for the UI
         this.wrappedMathFields = [];
-        // Record MathExpressions
-        this.mathExpressions = {};
     }
 
     setDefaults(settings) {
@@ -900,10 +898,8 @@ class MathObject {
         return defaults
     }
 
-    genMathExpression(expr, name) {
-        var mathExpr = new MathExpression(expr);
-        this.mathExpressions[name] = mathExpr;
-        return mathExpr
+    parseRawExpression(expr) {
+        return new MathExpression(expr);
     }
 
     serialize() {
@@ -1049,7 +1045,7 @@ class Variable extends AbstractVariable {
             rawExpression: {
                 set: function(val) {
                     this._rawExpression = val;
-                    _this.parsedExpression = _this.genMathExpression(val,'expression');
+                    _this.parsedExpression = _this.parseRawExpression(val);
                     _this.updateVariablesList();
                     _this.setRawExpression(val);
                 },
@@ -1081,7 +1077,7 @@ class Variable extends AbstractVariable {
     }
 
     setRawName(val) {
-        var expr = this.genMathExpression(val,'name');
+        var expr = this.parseRawExpression(val);
         // expr should be something like f_1(s,t); should have 1 function and 0+ variables
         if (expr.functions.length === 1) {
             this.holdEvaluation = true;
@@ -1248,12 +1244,12 @@ class VariableSlider extends AbstractVariable {
     }
 
     setMin(val) {
-        this.parsedMin = this.genMathExpression(val, 'min');
+        this.parsedMin = this.parseRawExpression(val);
         this.min = this.parsedMin.eval(this.scope);
         this.updateVariablesList();
     }
     setMax(val) {
-        this.parsedMax = this.genMathExpression(val, 'max');
+        this.parsedMax = this.parseRawExpression(val);
         this.max = this.parsedMax.eval(this.scope);
         this.updateVariablesList();
     }
@@ -1358,7 +1354,7 @@ class MathGraphic extends MathObject {
             rawExpression: {
                 set: function(val) {
                     this._rawExpression = val;
-                    _this.parsedExpression = _this.genMathExpression(val, 'expression');
+                    _this.parsedExpression = _this.parseRawExpression(val);
                     _this.updateVariablesList();
                     _this.recalculateData();
                 },
@@ -1598,7 +1594,7 @@ class MathGraphic extends MathObject {
     }
 
     setCalculatedVisibility(val){
-        this.parsedVisibility = this.genMathExpression(val, 'calculatedVisibility');
+        this.parsedVisibility = this.parseRawExpression(val);
         this.updateVariablesList();
         this.recalculateVisibility();
     }
@@ -1617,7 +1613,7 @@ class MathGraphic extends MathObject {
     }
 
     setRange(val) {
-        this.parsedRange = this.genMathExpression(val, 'range');
+        this.parsedRange = this.parseRawExpression(val);
         this.range = this.parsedRange.eval(this.math3d.mathScope);
         this.updateVariablesList();
         this.recalculateData();

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -2323,6 +2323,12 @@ class ExplicitSurfacePolar extends ParametricSurface {
     }
 }
 
+// TODO: toward improving parsing feedback, one idea is:
+// 1. move all MathExpressions associated with an object into obj.mathExpressions
+// 2. While I'm at it, remove all instances of this.parseRawExpression. It's a dumb method.
+// 3. Add an error message property to MathExpression class
+// 4. Now that every object has a mathExpressions list, append error messages to object in UI.
+
 // This should all really go into another file. It's specific to the math3d.org webapp design.
 
 // Customize MathQuill's MathField; bind to math3d MathObject

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -881,6 +881,9 @@ class MathObject {
 
         this.type = this.constructor.name;
         
+        // storage math expressions
+        this.parsed = {}
+        
         // Record all MathQuill mathfields associated with with this object for the UI
         this.wrappedMathFields = [];
     }
@@ -2324,6 +2327,11 @@ class ExplicitSurfacePolar extends ParametricSurface {
 }
 
 // TODO: toward improving parsing feedback, one idea is:
+// 1. refactor so setting min/max/expression/etc updates the existing MathExpression rather than creating a new one.
+// 2. Give each MathExpression an error attribute to store errors on update or creation
+// 3. For each MathObject, store parsed expressions in obj.parse
+
+// original idea:
 // 1. move all MathExpressions associated with an object into obj.mathExpressions
 // 2. While I'm at it, remove all instances of this.parseRawExpression. It's a dumb method.
 // 3. Add an error message property to MathExpression class

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -883,6 +883,8 @@ class MathObject {
         
         // Record all MathQuill mathfields associated with with this object for the UI
         this.wrappedMathFields = [];
+        // Record MathExpressions
+        this.mathExpressions = {};
     }
 
     setDefaults(settings) {
@@ -898,8 +900,10 @@ class MathObject {
         return defaults
     }
 
-    parseRawExpression(expr) {
-        return new MathExpression(expr);
+    genMathExpression(expr, name) {
+        var mathExpr = new MathExpression(expr);
+        this.mathExpressions[name] = mathExpr;
+        return mathExpr
     }
 
     serialize() {
@@ -1045,7 +1049,7 @@ class Variable extends AbstractVariable {
             rawExpression: {
                 set: function(val) {
                     this._rawExpression = val;
-                    _this.parsedExpression = _this.parseRawExpression(val);
+                    _this.parsedExpression = _this.genMathExpression(val,'expression');
                     _this.updateVariablesList();
                     _this.setRawExpression(val);
                 },
@@ -1077,7 +1081,7 @@ class Variable extends AbstractVariable {
     }
 
     setRawName(val) {
-        var expr = this.parseRawExpression(val);
+        var expr = this.genMathExpression(val,'name');
         // expr should be something like f_1(s,t); should have 1 function and 0+ variables
         if (expr.functions.length === 1) {
             this.holdEvaluation = true;
@@ -1244,12 +1248,12 @@ class VariableSlider extends AbstractVariable {
     }
 
     setMin(val) {
-        this.parsedMin = this.parseRawExpression(val);
+        this.parsedMin = this.genMathExpression(val, 'min');
         this.min = this.parsedMin.eval(this.scope);
         this.updateVariablesList();
     }
     setMax(val) {
-        this.parsedMax = this.parseRawExpression(val);
+        this.parsedMax = this.genMathExpression(val, 'max');
         this.max = this.parsedMax.eval(this.scope);
         this.updateVariablesList();
     }
@@ -1354,7 +1358,7 @@ class MathGraphic extends MathObject {
             rawExpression: {
                 set: function(val) {
                     this._rawExpression = val;
-                    _this.parsedExpression = _this.parseRawExpression(val);
+                    _this.parsedExpression = _this.genMathExpression(val, 'expression');
                     _this.updateVariablesList();
                     _this.recalculateData();
                 },
@@ -1594,7 +1598,7 @@ class MathGraphic extends MathObject {
     }
 
     setCalculatedVisibility(val){
-        this.parsedVisibility = this.parseRawExpression(val);
+        this.parsedVisibility = this.genMathExpression(val, 'calculatedVisibility');
         this.updateVariablesList();
         this.recalculateVisibility();
     }
@@ -1613,7 +1617,7 @@ class MathGraphic extends MathObject {
     }
 
     setRange(val) {
-        this.parsedRange = this.parseRawExpression(val);
+        this.parsedRange = this.genMathExpression(val, 'range');
         this.range = this.parsedRange.eval(this.math3d.mathScope);
         this.updateVariablesList();
         this.recalculateData();

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -1039,7 +1039,7 @@ class Variable extends AbstractVariable {
         super(math3d, settings);
         this.scope = math3d.mathScope;
         
-        this.parsedExpression = null;
+        this.parsed.expression = null;
         this.argNames = null;
         this.holdEvaluation = null;
 
@@ -1048,7 +1048,7 @@ class Variable extends AbstractVariable {
             rawExpression: {
                 set: function(val) {
                     this._rawExpression = val;
-                    _this.parsedExpression = _this.parseRawExpression(val);
+                    _this.parsed.expression = _this.parseRawExpression(val);
                     _this.updateVariablesList();
                     _this.setRawExpression(val);
                 },
@@ -1104,7 +1104,7 @@ class Variable extends AbstractVariable {
         return this.scope.addVariable(newName, this.value, onVariableChange);
     }
     setRawExpression(val) {
-        var expr = this.parsedExpression;
+        var expr = this.parsed.expression;
         if (!this.valid || expr === null) {
             return
         }
@@ -1131,9 +1131,9 @@ class Variable extends AbstractVariable {
     
     updateVariablesList() {
         this.variables = []
-        if (this.parsedExpression !== null) {
-            this.variables = this.variables.concat(this.parsedExpression.variables);
-            this.variables = this.variables.concat(this.parsedExpression.functions);
+        if (this.parsed.expression !== null) {
+            this.variables = this.variables.concat(this.parsed.expression.variables);
+            this.variables = this.variables.concat(this.parsed.expression.functions);
         }
     }
     recalculateData() {
@@ -1146,8 +1146,8 @@ class VariableSlider extends AbstractVariable {
         super(math3d, settings);
         this.scope = math3d.mathScope;
         
-        this.parsedMin = null;
-        this.parsedMax = null;
+        this.parsed.min = null;
+        this.parsed.max = null;
 
         this.speeds = [{
             value: 1 / 16,
@@ -1236,24 +1236,24 @@ class VariableSlider extends AbstractVariable {
 
     updateVariablesList() {
         this.variables = []
-        if (this.parsedMin !== null) {
-            this.variables = this.variables.concat(this.parsedMin.variables);
-            this.variables = this.variables.concat(this.parsedMin.functions);
+        if (this.parsed.min !== null) {
+            this.variables = this.variables.concat(this.parsed.min.variables);
+            this.variables = this.variables.concat(this.parsed.min.functions);
         }
-        if (this.parsedMax !== null) {
-            this.variables = this.variables.concat(this.parsedMax.variables);
-            this.variables = this.variables.concat(this.parsedMax.functions);
+        if (this.parsed.max !== null) {
+            this.variables = this.variables.concat(this.parsed.max.variables);
+            this.variables = this.variables.concat(this.parsed.max.functions);
         }
     }
 
     setMin(val) {
-        this.parsedMin = this.parseRawExpression(val);
-        this.min = this.parsedMin.eval(this.scope);
+        this.parsed.min = this.parseRawExpression(val);
+        this.min = this.parsed.min.eval(this.scope);
         this.updateVariablesList();
     }
     setMax(val) {
-        this.parsedMax = this.parseRawExpression(val);
-        this.max = this.parsedMax.eval(this.scope);
+        this.parsed.max = this.parseRawExpression(val);
+        this.max = this.parsed.max.eval(this.scope);
         this.updateVariablesList();
     }
     setValue(val) {
@@ -1329,11 +1329,11 @@ class MathGraphic extends MathObject {
         this.mathboxDataType = null; // e.g., 'array'
         this.mathboxRenderTypes = null; // e.g., 'point'
 
-        this.parsedExpression = null;
-        this.parsedRange = null;
+        this.parsed.expression = null;
+        this.parsed.range = null;
         this.variables = [];
         
-        this.parsedVisibility = null;
+        this.parsed.visibility = null;
         this.toggleVariables = [];
 
         this.settings = {};
@@ -1357,7 +1357,7 @@ class MathGraphic extends MathObject {
             rawExpression: {
                 set: function(val) {
                     this._rawExpression = val;
-                    _this.parsedExpression = _this.parseRawExpression(val);
+                    _this.parsed.expression = _this.parseRawExpression(val);
                     _this.updateVariablesList();
                     _this.recalculateData();
                 },
@@ -1539,18 +1539,18 @@ class MathGraphic extends MathObject {
 
     updateVariablesList() {
         this.variables = []
-        if (this.parsedExpression !== null) {
-            this.variables = this.variables.concat(this.parsedExpression.variables);
-            this.variables = this.variables.concat(this.parsedExpression.functions);
+        if (this.parsed.expression !== null) {
+            this.variables = this.variables.concat(this.parsed.expression.variables);
+            this.variables = this.variables.concat(this.parsed.expression.functions);
         }
 
-        if (this.parsedRange !== null) {
-            this.variables = this.variables.concat(this.parsedRange.variables);
-            this.variables = this.variables.concat(this.parsedRange.functions);
+        if (this.parsed.range !== null) {
+            this.variables = this.variables.concat(this.parsed.range.variables);
+            this.variables = this.variables.concat(this.parsed.range.functions);
         }
         
-        if (this.parsedVisibility !== null){
-            this.toggleVariables = this.toggleVariables.concat(this.parsedVisibility.variables);
+        if (this.parsed.visibility !== null){
+            this.toggleVariables = this.toggleVariables.concat(this.parsed.visibility.variables);
         }
     }
 
@@ -1597,14 +1597,14 @@ class MathGraphic extends MathObject {
     }
 
     setCalculatedVisibility(val){
-        this.parsedVisibility = this.parseRawExpression(val);
+        this.parsed.visibility = this.parseRawExpression(val);
         this.updateVariablesList();
         this.recalculateVisibility();
     }
     
     recalculateVisibility(){
         try {
-            this.settings.visible = this.parsedVisibility.eval(this.math3d.toggleScope);
+            this.settings.visible = this.parsed.visibility.eval(this.math3d.toggleScope);
         } 
         catch (e) {
             console.log(e.message);
@@ -1616,8 +1616,8 @@ class MathGraphic extends MathObject {
     }
 
     setRange(val) {
-        this.parsedRange = this.parseRawExpression(val);
-        this.range = this.parsedRange.eval(this.math3d.mathScope);
+        this.parsed.range = this.parseRawExpression(val);
+        this.range = this.parsed.range.eval(this.math3d.mathScope);
         this.updateVariablesList();
         this.recalculateData();
     }
@@ -1698,7 +1698,7 @@ class Point extends MathGraphic {
     }
 
     recalculateData() {
-        this.data = this.parsedExpression.eval(this.math3d.mathScope);
+        this.data = this.parsed.expression.eval(this.math3d.mathScope);
     }
 
     render() {
@@ -1774,7 +1774,7 @@ class AbstractCurveFromData extends AbstractCurve {
     }
 
     recalculateData() {
-        this.data = this.parsedExpression.eval(this.math3d.mathScope);
+        this.data = this.parsed.expression.eval(this.math3d.mathScope);
     }
 
     render() {
@@ -1949,11 +1949,11 @@ class ParametricCurve extends AbstractCurve {
     recalculateData() {
         if (this.mathboxGroup !== null) {
             this.mathboxGroup.select("cartesian").set("range", [this.range, [0, 1]]);
-            var expr = this.parsedExpression;
+            var expr = this.parsed.expression;
             var localMathScope = Utility.deepCopyValuesOnly(this.math3d.mathScope);
             var param = this.settings.parameter;
 
-            this.range = this.parsedRange.eval(this.math3d.mathScope);
+            this.range = this.parsed.range.eval(this.math3d.mathScope);
             this.mathboxGroup.select("cartesian").set("range", [this.range, [0, 1]]);
             this.mathboxGroup.select("interval").set("width", this.settings.samples);
 
@@ -1969,7 +1969,7 @@ class ParametricCurve extends AbstractCurve {
     render() {
         // NOTE: Updating an <area>'s range does not work. However, it does work to make range a child of its own <cartesian>, inherit range from cartesian, and update <cartesian>'s range. See https://groups.google.com/forum/?fromgroups#!topic/mathbox/zLX6WJjTDZk
         var group = this.math3d.scene.group().set('classes', ['curve', 'parametric']);
-        var expr = this.parsedExpression;
+        var expr = this.parsed.expression;
         var localMathScope = Utility.deepCopyValuesOnly(this.math3d.mathScope);
         var param = this.settings.parameter[0];
 
@@ -2172,12 +2172,12 @@ class ParametricSurface extends AbstractSurface {
         if (this.mathboxGroup !== null) {
             this.mathboxGroup.select("cartesian").set("range", this.range);
 
-            var expr = this.parsedExpression;
+            var expr = this.parsed.expression;
             var localMathScope = Utility.deepCopyValuesOnly(this.math3d.mathScope);
             var param0 = this.settings.parameters[0];
             var param1 = this.settings.parameters[1];
             
-            this.range = this.parsedRange.eval(this.math3d.mathScope);
+            this.range = this.parsed.range.eval(this.math3d.mathScope);
             this.mathboxGroup.select("cartesian").set("range", this.range);
 
             this.mathboxGroup.select("area").set("width", this.settings.samplesU);
@@ -2195,7 +2195,7 @@ class ParametricSurface extends AbstractSurface {
     render() {
         // NOTE: Updating an <area>'s range does not work. However, it does work to make range a child of its own <cartesian>, inherit range from cartesian, and update <cartesian>'s range. See https://groups.google.com/forum/?fromgroups#!topic/mathbox/zLX6WJjTDZk
         var group = this.math3d.scene.group().set('classes', ['surface', 'parametric']);
-        var expr = this.parsedExpression;
+        var expr = this.parsed.expression;
         var localMathScope = Utility.deepCopyValuesOnly(this.math3d.mathScope);
         var param0 = this.settings.parameters[0];
         var param1 = this.settings.parameters[1];

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -781,6 +781,7 @@ class MathExpression {
     update(){
         try {
             this.parsed = this.parse();
+            this.err = null;
         } catch (err) {
             this.err = err
             throw (err)
@@ -813,7 +814,9 @@ class MathExpression {
         if (this.expression[0] == "[") {
             this.eval = function(scope) {
                 try {
-                    return compiled.eval(scope).toArray();
+                    var val = compiled.eval(scope).toArray();
+                    this.err = null;
+                    return val;
                 } 
                 catch (err) {
                     this.err = err;
@@ -822,12 +825,13 @@ class MathExpression {
         } else {
             this.eval = function(scope) {
                 try {
-                    return compiled.eval(scope);
+                    var val = compiled.eval(scope);
+                    this.err = null;
+                    return val;
                 } 
                 catch (err) {
                     this.err=err;
                 }
-                
             }
         }
     }

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -2414,13 +2414,8 @@ class WrappedMathField {
     }
     
     updateMathObj(key){
-        try {
-            this.mathObj.settings[key] = MathUtility.texToMathJS(this.mathfield.latex());
-            this.$scope.$apply(); // for variables, changing the name can change object description from between variable and function. Propagating this change requires an apply().
-        } 
-        catch (e) {
-            console.log(e.message);
-        }
+        this.mathObj.settings[key] = MathUtility.texToMathJS(this.mathfield.latex());
+        this.$scope.$apply(); // for variables, changing the name can change object description from between variable and function. Propagating this change requires an apply().
     }
     
 }

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -1318,7 +1318,7 @@ class VariableSlider extends AbstractVariable {
     }
 }
 
-class VariableToggle extends AbstractVariable{
+class VariableToggle extends AbstractVariable {
     constructor(math3d, settings) {
         super(math3d, settings);
         this.scope = math3d.toggleScope;

--- a/resources/math3d.js
+++ b/resources/math3d.js
@@ -2008,7 +2008,7 @@ class ParametricCurve extends AbstractCurve {
     }
 
     render() {
-        // NOTE: Updating an <area>'s range does not work. However, it does work to make range a child of its own <cartesian>, inherit range from cartesian, and update <cartesian>'s range. See https://groups.google.com/forum/?fromgroups#!topic/mathbox/zLX6WJjTDZk
+        // NOTE: Updating an <interval>'s range does not work. However, it does work to make interval a child of its own <cartesian>, inherit range from cartesian, and update <cartesian>'s range. See https://groups.google.com/forum/?fromgroups#!topic/mathbox/zLX6WJjTDZk
         var group = this.math3d.scene.group().set('classes', ['curve', 'parametric']);
         var expr = this.parsed.expression;
         var localMathScope = Utility.deepCopyValuesOnly(this.math3d.mathScope);
@@ -2372,11 +2372,9 @@ class ExplicitSurfacePolar extends ParametricSurface {
 // 2. Give each MathExpression an error attribute to store errors on update or creation
 // 3. For each MathObject, store parsed expressions in obj.parse
 
-// original idea:
-// 1. move all MathExpressions associated with an object into obj.mathExpressions
-// 2. While I'm at it, remove all instances of this.parseRawExpression. It's a dumb method.
-// 3. Add an error message property to MathExpression class
-// 4. Now that every object has a mathExpressions list, append error messages to object in UI.
+// TODO:
+// MathGraphics have some copied code. Also, the top MathGraphic class defines a bunch of setters and getters that several subclasses don't use.
+// Could mixins help clean this up? Idea: the classes only define recalculateData and render methods. Everything else is mixed in.
 
 // This should all really go into another file. It's specific to the math3d.org webapp design.
 

--- a/resources/math3d_app.css
+++ b/resources/math3d_app.css
@@ -197,6 +197,9 @@ span.folder-name-editable{
     color:lightgray;
     visibility:hidden;
 }
+.folder-main div.folder-contents {
+    padding-left:0px;
+}
 
 .has-error.has-feedback, .has-error.has-feedback:focus,
 .mq-editable-field.has-error.has-feedback,


### PR DESCRIPTION
Refactor `MathExpression` class and so that:

- editing `MathObject` does not create new `MathExpressions`, just updates the old `MathExpression`
- `MathExpression`s keep track of error messages