### PR TITLE
Navbar toggle

### DIFF
--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -182,10 +182,13 @@ input {
 /**************************************************/
 /* Main */
 /**************************************************/
+.main {
+  position:relative;
+}
+
 .sidepanel {
     position:absolute;
     left:0;
-    top:30px; /*navbar height*/
     z-index:1;
 }
 .math3d-controller {

--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -183,9 +183,8 @@ input {
 /* Main */
 /**************************************************/
 .sidepanel {
-    position:absolute;
+    position:fixed;
     left:0;
-    top:30px; /*navbar height*/
     z-index:1000;
 }
 .math3d-controller {

--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -184,6 +184,8 @@ input {
 /**************************************************/
 .main {
   position:relative;
+  margin:0;
+  padding:0;
 }
 
 .sidepanel {

--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -168,9 +168,15 @@ input {
     margin-bottom:5px;
 }
 
-.navbar a.navbar-brand {
+.navbar span.navbar-brand {
     font-weight: 900;
     color:#bfbfbf;
+}
+
+.navbar .navbar-brand:hover, 
+.navbar .navbar-brand:focus {
+  background-color: transparent;
+  color: #bfbfbf;
 }
 
 /**************************************************/

--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -186,7 +186,7 @@ input {
     position:absolute;
     left:0;
     top:30px; /*navbar height*/
-    z-index:1000;
+    z-index:1;
 }
 .math3d-controller {
     margin-left:25px;

--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -183,8 +183,9 @@ input {
 /* Main */
 /**************************************************/
 .sidepanel {
-    position:fixed;
+    position:absolute;
     left:0;
+    top:30px; /*navbar height*/
     z-index:1000;
 }
 .math3d-controller {

--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -386,7 +386,7 @@ span.label-and-description:hover span.edit-label{
 /**************************************************/
 /* Toggle Sidebar Controller */
 /**************************************************/
-.math3d-controller-animation {
+.sidepanel-animation {
     transition: left 1s;
 }
 

--- a/static/resources/templates/help_popover.html
+++ b/static/resources/templates/help_popover.html
@@ -1,4 +1,4 @@
-<section style="width:250px">
+<section>
   <h4 style="margin-top:0pt" class='text-center'>Help / Contact</h4>
   <button type="button" class="btn btn-link btn-xs btn-quiet pull-upper-right" ng-click="modalpopHide()">
       <span class="glyphicon glyphicon-remove"></span>

--- a/static/resources/templates/help_popover.html
+++ b/static/resources/templates/help_popover.html
@@ -1,6 +1,6 @@
 <section style="width:250px">
   <h4 style="margin-top:0pt" class='text-center'>Help / Contact</h4>
-  <button type="button" class="btn btn-link btn-xs btn-quiet pull-upper-right" ng-click="myPopover.close()">
+  <button type="button" class="btn btn-link btn-xs btn-quiet pull-upper-right" ng-click="modalpopHide()">
       <span class="glyphicon glyphicon-remove"></span>
   </button>
   <p><a href="http://math3d.org">Math3d.org</a> is a work in progress. Have a question? Suggestion? Found a bug?</p>

--- a/static/vendors/angular-popeye/.bower.json
+++ b/static/vendors/angular-popeye/.bower.json
@@ -1,0 +1,57 @@
+{
+  "name": "angular-popeye",
+  "homepage": "https://github.com/Pathgather/popeye",
+  "authors": [
+    {
+      "name": "Pathgather",
+      "email": "tech@pathgather.com"
+    }
+  ],
+  "description": "A simple modal library for AngularJS applications",
+  "main": [
+    "release/popeye.js",
+    "release/popeye.css"
+  ],
+  "dependencies": {
+    "angular": "^1.3.14"
+  },
+  "moduleType": [
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "angular",
+    "modal",
+    "popup",
+    "angularjs",
+    "popeye",
+    "window"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Pathgather/popeye"
+  },
+  "license": "MIT",
+  "ignore": [
+    "node_modules",
+    "bower_components",
+    "src",
+    "test",
+    "demo",
+    "Gruntfile.coffee",
+    "LICENSE",
+    "karma.conf.coffee",
+    "package.json"
+  ],
+  "version": "1.0.5",
+  "_release": "1.0.5",
+  "_resolution": {
+    "type": "version",
+    "tag": "v1.0.5",
+    "commit": "fa8982bc4cd8ea44d2668ca6c37c08a1a8ea55ef"
+  },
+  "_source": "https://github.com/Pathgather/popeye.git",
+  "_target": "^1.0.5",
+  "_originalSource": "angular-popeye",
+  "_direct": true
+}

--- a/static/vendors/angular-popeye/.gitignore
+++ b/static/vendors/angular-popeye/.gitignore
@@ -1,0 +1,6 @@
+*.log
+.DS_Store
+node_modules
+bower_components
+.sass-cache/
+.tmp/

--- a/static/vendors/angular-popeye/popeye.css
+++ b/static/vendors/angular-popeye/popeye.css
@@ -1,0 +1,128 @@
+/**
+* angular-popeye
+* A simple modal library for AngularJS applications
+
+* @author Pathgather <tech@pathgather.com>
+* @copyright Pathgather 2015
+* @license MIT
+* @link https://github.com/Pathgather/popeye
+* @version 1.0.5
+*/
+
+body.popeye-modal-open {
+  overflow: hidden; }
+
+.popeye-modal-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  z-index: 5;
+  overflow-y: auto;
+  background-color: rgba(76, 147, 234, 0.7);
+  text-align: center;
+  /* "ghost" element to use for vertical alignment
+    (see https://css-tricks.com/centering-in-the-unknown/) */ }
+  .popeye-modal-container.ng-enter {
+    -webkit-animation: popeye-fade-in 0.4s;
+            animation: popeye-fade-in 0.4s; }
+    .popeye-modal-container.ng-enter .popeye-modal {
+      -webkit-animation: popeye-slide-up 0.4s;
+              animation: popeye-slide-up 0.4s; }
+  .popeye-modal-container.ng-leave {
+    -webkit-animation: popeye-fade-out 0.4s;
+            animation: popeye-fade-out 0.4s; }
+    .popeye-modal-container.ng-leave .popeye-modal {
+      -webkit-animation: popeye-slide-down 0.4s forwards;
+              animation: popeye-slide-down 0.4s forwards; }
+  .popeye-modal-container::before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle; }
+  .popeye-modal-container .popeye-modal {
+    position: relative;
+    text-align: left;
+    vertical-align: middle;
+    display: inline-block;
+    width: 60%;
+    border-radius: 3px;
+    border: none;
+    z-index: 6;
+    padding: 2em 1.5em 1.5em 1.5em;
+    background: white;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.4); }
+    .popeye-modal-container .popeye-modal a.popeye-close-modal {
+      position: absolute;
+      top: 1em;
+      right: 1em;
+      font-weight: 100;
+      text-decoration: none;
+      color: inherit; }
+      .popeye-modal-container .popeye-modal a.popeye-close-modal::after {
+        content: "\d7"; }
+
+@-webkit-keyframes popeye-slide-up {
+  0% {
+    opacity: 0;
+    -webkit-transform: translateY(100%);
+            transform: translateY(100%); }
+  100% {
+    opacity: 1;
+    -webkit-transform: translateY(0%);
+            transform: translateY(0%); } }
+
+@keyframes popeye-slide-up {
+  0% {
+    opacity: 0;
+    -webkit-transform: translateY(100%);
+            transform: translateY(100%); }
+  100% {
+    opacity: 1;
+    -webkit-transform: translateY(0%);
+            transform: translateY(0%); } }
+
+@-webkit-keyframes popeye-slide-down {
+  0% {
+    opacity: 1;
+    -webkit-transform: translateY(0%);
+            transform: translateY(0%); }
+  100% {
+    opacity: 0;
+    -webkit-transform: translateY(100%);
+            transform: translateY(100%); } }
+
+@keyframes popeye-slide-down {
+  0% {
+    opacity: 1;
+    -webkit-transform: translateY(0%);
+            transform: translateY(0%); }
+  100% {
+    opacity: 0;
+    -webkit-transform: translateY(100%);
+            transform: translateY(100%); } }
+
+@-webkit-keyframes popeye-fade-in {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+
+@keyframes popeye-fade-in {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+
+@-webkit-keyframes popeye-fade-out {
+  0% {
+    opacity: 1; }
+  100% {
+    opacity: 0; } }
+
+@keyframes popeye-fade-out {
+  0% {
+    opacity: 1; }
+  100% {
+    opacity: 0; } }

--- a/static/vendors/angular-popeye/popeye.js
+++ b/static/vendors/angular-popeye/popeye.js
@@ -1,0 +1,258 @@
+/**
+* angular-popeye
+* A simple modal library for AngularJS applications
+
+* @author Pathgather <tech@pathgather.com>
+* @copyright Pathgather 2015
+* @license MIT
+* @link https://github.com/Pathgather/popeye
+* @version 1.0.5
+*/
+
+(function() {
+  var angular, popeye,
+    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
+  popeye = function(angular) {
+    "use strict";
+    var mod;
+    mod = angular.module("pathgather.popeye", []);
+    return mod.provider("Popeye", function() {
+      var PopeyeProvider;
+      return PopeyeProvider = {
+        defaults: {
+          containerTemplate: "<div class=\"popeye-modal-container\">\n  <div class=\"popeye-modal\">\n    <a class=\"popeye-close-modal\" href ng-click=\"$close()\"></a>\n  </div>\n</div>",
+          containerTemplateUrl: null,
+          bodyClass: "popeye-modal-open",
+          containerClass: null,
+          modalClass: null,
+          locals: null,
+          resolve: null,
+          scope: null,
+          controller: null,
+          keyboard: true,
+          click: true
+        },
+        $get: ["$q", "$animate", "$rootScope", "$document", "$http", "$templateCache", "$compile", "$controller", "$injector", function($q, $animate, $rootScope, $document, $http, $templateCache, $compile, $controller, $injector) {
+          var PopeyeModal, currentModal, pendingPromise;
+          currentModal = null;
+          pendingPromise = null;
+          $document.on("keydown", function(evt) {
+            if (evt.which === 27 && (currentModal != null) && currentModal.options.keyboard) {
+              return currentModal.close({
+                reason: "keyboard"
+              });
+            }
+          });
+          PopeyeModal = (function() {
+            function PopeyeModal(options) {
+              if (options == null) {
+                options = {};
+              }
+              this.handleError = bind(this.handleError, this);
+              this.close = bind(this.close, this);
+              this.open = bind(this.open, this);
+              this.resolve = bind(this.resolve, this);
+              if (!((options.template != null) || (options.templateUrl != null))) {
+                throw new Error("template or templateUrl must be provided");
+              }
+              this.options = angular.extend(angular.copy(PopeyeProvider.defaults), options);
+              this.resolvedDeferred = $q.defer();
+              this.resolved = this.resolvedDeferred.promise;
+              this.openedDeferred = $q.defer();
+              this.opened = this.openedDeferred.promise;
+              this.closedDeferred = $q.defer();
+              this.closed = this.closedDeferred.promise;
+            }
+
+            PopeyeModal.prototype.resolve = function() {
+              if (this.resolving) {
+                return this.resolved;
+              }
+              this.resolving = true;
+              $q.when({}).then((function(_this) {
+                return function() {
+                  var locals, resolve;
+                  locals = angular.extend({
+                    modal: _this
+                  }, _this.options.locals);
+                  resolve = angular.extend({}, _this.options.resolve);
+                  angular.forEach(resolve, function(value, key) {
+                    return locals[key] = angular.isString(value) ? $injector.get(value) : $injector.invoke(value, null, locals);
+                  });
+                  return $q.all(locals);
+                };
+              })(this)).then((function(_this) {
+                return function(resolved) {
+                  _this.scope = _this.options.scope != null ? _this.options.scope : $rootScope.$new();
+                  _this.scope.$close = function() {
+                    return _this.close.apply(_this, arguments);
+                  };
+                  if (_this.options.controller) {
+                    _this.controller = $controller(_this.options.controller, angular.extend({
+                      $scope: _this.scope
+                    }, resolved));
+                  }
+                  return _this.resolvedDeferred.resolve(_this);
+                };
+              })(this), (function(_this) {
+                return function(error) {
+                  return _this.handleError(error);
+                };
+              })(this));
+              return this.resolved;
+            };
+
+            PopeyeModal.prototype.open = function() {
+              var promise;
+              if (this.opening) {
+                return this.opened;
+              }
+              this.opening = true;
+              promise = pendingPromise != null ? pendingPromise = pendingPromise.then((function(_this) {
+                return function(prevModal) {
+                  return prevModal.close().then(function() {
+                    return _this;
+                  });
+                };
+              })(this)) : currentModal != null ? pendingPromise = currentModal.close().then((function(_this) {
+                return function() {
+                  return _this;
+                };
+              })(this)) : (pendingPromise = this.opened, $q.when());
+              promise.then((function(_this) {
+                return function() {
+                  return _this.resolve().then(function() {
+                    var containerPromise;
+                    if (_this.scope == null) {
+                      throw new Error("@scope is undefined");
+                    }
+                    containerPromise = _this.options.containerTemplate != null ? $q.when({
+                      data: _this.options.containerTemplate
+                    }) : _this.options.containerTemplateUrl != null ? $http.get(_this.options.containerTemplateUrl, {
+                      cache: $templateCache
+                    }) : $q.reject("Missing containerTemplate or containerTemplateUrl");
+                    return containerPromise.then(function(containerTmpl) {
+                      var containerElement, templatePromise;
+                      containerElement = angular.element(containerTmpl.data);
+                      if (_this.options.containerClass) {
+                        containerElement.addClass(_this.options.containerClass);
+                      }
+                      templatePromise = _this.options.template != null ? $q.when({
+                        data: _this.options.template
+                      }) : _this.options.templateUrl != null ? $http.get(_this.options.templateUrl, {
+                        cache: $templateCache
+                      }) : $q.reject("Missing containerTemplate or containerTemplateUrl");
+                      return templatePromise.then(function(tmpl) {
+                        var body, bodyLastChild;
+                        angular.element(containerElement[0].querySelector(".popeye-modal")).append(tmpl.data);
+                        if (_this.options.click) {
+                          containerElement.on("click", function(evt) {
+                            if (evt.target === evt.currentTarget) {
+                              return _this.close();
+                            }
+                          });
+                        }
+                        _this.container = $compile(containerElement)(_this.scope);
+                        _this.element = angular.element(_this.container[0].querySelector(".popeye-modal"));
+                        if (_this.options.modalClass) {
+                          _this.element.addClass(_this.options.modalClass);
+                        }
+                        body = $document.find("body");
+                        if (body[0].lastChild) {
+                          bodyLastChild = angular.element(body[0].lastChild);
+                        }
+                        if (_this.options.bodyClass) {
+                          body.addClass(_this.options.bodyClass);
+                        }
+                        return $animate.enter(_this.container, body, bodyLastChild).then(function() {
+                          currentModal = _this;
+                          return _this.openedDeferred.resolve(_this);
+                        });
+                      });
+                    });
+                  });
+                };
+              })(this))["catch"]((function(_this) {
+                return function(error) {
+                  return _this.handleError(error);
+                };
+              })(this))["finally"](function() {
+                return pendingPromise = null;
+              });
+              return this.opened;
+            };
+
+            PopeyeModal.prototype.close = function(value) {
+              if (this.closing) {
+                return this.closed;
+              }
+              this.closing = true;
+              this.opened.then((function(_this) {
+                return function() {
+                  if (_this.container == null) {
+                    throw new Error("@container is undefined");
+                  }
+                  return $animate.leave(_this.container).then(function() {
+                    currentModal = null;
+                    if (!_this.options.scope) {
+                      _this.scope.$destroy();
+                    }
+                    $document.find("body").removeClass(_this.options.bodyClass);
+                    return _this.closedDeferred.resolve(value);
+                  }, function(error) {
+                    return _this.handleError(error);
+                  });
+                };
+              })(this));
+              return this.closed;
+            };
+
+            PopeyeModal.prototype.handleError = function(error) {
+              this.resolvedDeferred.reject(error);
+              this.openedDeferred.reject(error);
+              return this.closedDeferred.reject(error);
+            };
+
+            return PopeyeModal;
+
+          })();
+          return {
+            openModal: function(options) {
+              var modal;
+              if (options == null) {
+                options = {};
+              }
+              modal = new PopeyeModal(options);
+              modal.open();
+              return modal;
+            },
+            closeCurrentModal: function(value) {
+              if (currentModal != null) {
+                currentModal.close(value);
+              }
+              return currentModal;
+            },
+            isModalOpen: function() {
+              return !!currentModal;
+            }
+          };
+        }]
+      };
+    });
+  };
+
+  if ((typeof window !== "undefined" && window !== null ? window.angular : void 0) != null) {
+    popeye(window.angular);
+  } else if (typeof require === "function") {
+    angular = require("angular");
+    popeye(angular);
+  } else {
+    throw new Error("Could not find angular on window nor via require()");
+  }
+
+  if (typeof module !== "undefined" && module !== null) {
+    module.exports = "pathgather.popeye";
+  }
+
+}).call(this);

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,7 @@
         </div>
         <div class="collapse navbar-collapse" id="myNavbar">
           <ul class="nav navbar-nav navbar-right">
-            <li id="navbartest" class="modalpop-popover-mode" modalpop modalpop-content-url="'/static/resources/templates/help_popover.html'">
+            <li id="navbartest" modalpop modalpop-content-url="'/static/resources/templates/help_popover.html'">
               <a class="modalpop-trigger" href="#">
                 <span class="glyphicon glyphicon-question-sign"></span> Help/Contact
               </a>
@@ -93,7 +93,7 @@
   </header>
 
   <div class="container" ng-controller="checkLoginCtrl">
-    <div class="sidepanel menu-visible">
+    <div class="sidepanel menu-visible sidepanel-animation">
       <div class="math3d-controller">
       
         <div class="math3d-controller-header">
@@ -309,30 +309,38 @@ function toggleMenu(){
   }
 };
 
-function hideForSmallWindow(){
+function hideSidepanelForSmallWindow(){
+  if ($(ele).hasClass('manually-toggled')){
+    return
+  }
   if (! window.matchMedia("(min-width: 768px)").matches) {
     hideMnu();
   }
 }
-function showForLargeWindow(ele){
+function showSidepanelForSmallWindow(ele){
   if (window.matchMedia("(min-width: 768px)").matches) {
     showMenu();
   }
 }
 
-hideForSmallWindow(ele);
-ele.addClass("math3d-controller-animation")
-
+// hideSidepanelForSmallWindow(ele);
+// ele.addClass("sidepanel-animation")
 $(window).resize(function(e){
-  if ($(ele).hasClass('manually-toggled')){
-    return
-  }
   if ($(ele).hasClass('menu-visible')){
-    hideForSmallWindow();
+    hideSidepanelForSmallWindow();
   } else {
-    showForLargeWindow();
+    showSidepanelForSmallWindow();
   }
 })
+$(window).resize(function(e){
+  if (! window.matchMedia("(min-width: 768px)").matches) {
+    $('[modalpop]').removeClass('modalpop-popover-mode')
+  } 
+  else {
+    $('[modalpop]').addClass('modalpop-popover-mode')
+  }
+})
+$(window).trigger('resize')
 
 $("#menu-toggle").click(function(e) {
   toggleMenu(e);

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,6 +55,10 @@
   <script src="/static/vendors/angular-tree/source/directives/uiTreeNodes.js"></script>
   <script src="/static/vendors/angular-tree/source/services/helper.js"></script>
   
+  <!--Angular Popeye Modals -->
+  <script src="static/vendors/angular-popeye/popeye.js"></script>
+  <link rel="stylesheet" href="static/vendors/angular-popeye/popeye.css">
+  
   <link  href="/static/vendors/angular-bootstrap-toggle/angular-bootstrap-toggle.min.css" rel="stylesheet">
   <script src="/static/vendors/angular-bootstrap-toggle/angular-bootstrap-toggle.min.js"></script>
   
@@ -77,15 +81,8 @@
         </div>
         <div class="collapse navbar-collapse" id="myNavbar">
           <ul class="nav navbar-nav navbar-right">
-            <li ng-controller="popoverCtrl"
-                popover-is-open="myPopover.isOpen"  
-                popover-class="popover-settings"
-                uib-popover-template="'/static/resources/templates/help_popover.html'" 
-                popover-placement="auto" 
-                popover-trigger="outsideClick"
-                popover-append-to-body="false"
-                >
-              <a class="popover-trigger" href="#">
+            <li id="navbartest" class="modalpop-popover-mode" modalpop modalpop-content-url="'/static/resources/templates/help_popover.html'">
+              <a class="modalpop-trigger" href="#">
                 <span class="glyphicon glyphicon-question-sign"></span> Help/Contact
               </a>
             </li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -92,7 +92,7 @@
     </nav>
   </header>
 
-  <div class="container" ng-controller="checkLoginCtrl">
+  <div class="container main" ng-controller="checkLoginCtrl">
     <div class="sidepanel menu-visible sidepanel-animation">
       <div class="math3d-controller">
       

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,8 +56,8 @@
   <script src="/static/vendors/angular-tree/source/services/helper.js"></script>
   
   <!--Angular Popeye Modals -->
-  <script src="static/vendors/angular-popeye/popeye.js"></script>
-  <link rel="stylesheet" href="static/vendors/angular-popeye/popeye.css">
+  <script src="/static/vendors/angular-popeye/popeye.js"></script>
+  <link rel="stylesheet" href="/static/vendors/angular-popeye/popeye.css">
   
   <link  href="/static/vendors/angular-bootstrap-toggle/angular-bootstrap-toggle.min.css" rel="stylesheet">
   <script src="/static/vendors/angular-bootstrap-toggle/angular-bootstrap-toggle.min.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,7 +68,7 @@
     <nav class="navbar navbar-default">
       <div class="container-fluid">
         <div class="navbar-header">
-          <a class="navbar-brand" href="#">Math3d</a>
+          <span class="navbar-brand" href="#">Math3d</span>
         </div>
         <ul class="nav navbar-nav navbar-right">
           <li ng-controller="popoverCtrl"

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,22 +68,29 @@
     <nav class="navbar navbar-default">
       <div class="container-fluid">
         <div class="navbar-header">
+          <button type="button" class="navbar-toggle" style="height:25px;margin:3px;padding:3px" data-toggle="collapse" data-target="#myNavbar">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>                        
+          </button>
           <span class="navbar-brand" href="#">Math3d</span>
         </div>
-        <ul class="nav navbar-nav navbar-right">
-          <li ng-controller="popoverCtrl"
-              popover-is-open="myPopover.isOpen"  
-              popover-class="popover-settings"
-              uib-popover-template="'/static/resources/templates/help_popover.html'" 
-              popover-placement="auto" 
-              popover-trigger="outsideClick"
-              popover-append-to-body="false"
-              >
-            <a class="popover-trigger" href="#">
-              <span class="glyphicon glyphicon-question-sign"></span> Help/Contact
-            </a>
-          </li>
-        </ul>
+        <div class="collapse navbar-collapse" id="myNavbar">
+          <ul class="nav navbar-nav navbar-right">
+            <li ng-controller="popoverCtrl"
+                popover-is-open="myPopover.isOpen"  
+                popover-class="popover-settings"
+                uib-popover-template="'/static/resources/templates/help_popover.html'" 
+                popover-placement="auto" 
+                popover-trigger="outsideClick"
+                popover-append-to-body="false"
+                >
+              <a class="popover-trigger" href="#">
+                <span class="glyphicon glyphicon-question-sign"></span> Help/Contact
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </nav>
   </header>


### PR DESCRIPTION
This PR includes a few updates to the navigation bar. Most notably:

- Navigation bar now collapses on small screens (below `min-width: 768px`). 
- Help/Contact link has been changed to a custom angular directive `modalpop`. On small screens, `modalpop` appears as a modal overlay and on large screens appears as a popover.
- sidepanel vertical positioning has also been improved. It now slides down properly when navbar increases in height.

Changes are like at [math3dstaging](http://math3dstaging.herokuapp.com).