### PR TITLE
assign ng-model to math3d.settings instead of settings

### DIFF
--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -222,7 +222,7 @@ app.controller('graphListCtrl', ['$rootScope', '$scope', '$http', function($root
 }]);
 
 app.controller('settingsCtrl', ['$scope', function($scope){
-    $scope.settings = math3d.settings;
+    $scope.math3d = math3d;
 }])
 
 app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {    

--- a/static/resources/templates/axes_settings.html
+++ b/static/resources/templates/axes_settings.html
@@ -5,26 +5,26 @@
       <div class="col-xs-6">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.axes.x.visible"/> <strong>X-axis</strong>
+            <input type="checkbox" ng-model = "math3d.settings.axes.x.visible"/> <strong>X-axis</strong>
           </label>
         </div>
       </div>
       <div class="col-xs-6">
         <label>
-          <input type="text" class="form-control input-xs" placeholder="Add label" ng-model = "settings.axes.x.axisLabel">
+          <input type="text" class="form-control input-xs" placeholder="Add label" ng-model = "math3d.settings.axes.x.axisLabel">
         </label>
       </div>
     </div>
     <div class="row">
       <div class="col-xs-7">
-        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "settings.range.xMin">
+        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "math3d.settings.range.xMin">
         <span>≤ X ≤</span>
-        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "settings.range.xMax">
+        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "math3d.settings.range.xMax">
       </div>
       <div class="col-xs-5">
         <label style="font-weight:normal">
           Scale:
-          <input style="width:40px;display:inline-block" class="form-control input-xs" type="number" ng-model = "settings.scale.x">
+          <input style="width:40px;display:inline-block" class="form-control input-xs" type="number" ng-model = "math3d.settings.scale.x">
         </label>
       </div>
     </div>
@@ -32,7 +32,7 @@
       <div class="col-xs-5 col-xs-offset-7">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.axes.x.ticksVisible"/> Ticks
+            <input type="checkbox" ng-model = "math3d.settings.axes.x.ticksVisible"/> Ticks
           </label>
         </div>
       </div>
@@ -43,26 +43,26 @@
       <div class="col-xs-6">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.axes.y.visible"/> <strong>Y-axis</strong>
+            <input type="checkbox" ng-model = "math3d.settings.axes.y.visible"/> <strong>Y-axis</strong>
           </label>
         </div>
       </div>
       <div class="col-xs-6">
         <label>
-          <input type="text" class="form-control input-xs" placeholder="Add label" ng-model = "settings.axes.y.axisLabel">
+          <input type="text" class="form-control input-xs" placeholder="Add label" ng-model = "math3d.settings.axes.y.axisLabel">
         </label>
       </div>
     </div>
     <div class="row">
       <div class="col-xs-7">
-        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "settings.range.yMin">
+        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "math3d.settings.range.yMin">
         <span>≤ Y ≤</span>
-        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "settings.range.yMax">
+        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "math3d.settings.range.yMax">
       </div>
       <div class="col-xs-5">
         <label style="font-weight:normal">
           Scale:
-          <input style="width:40px;display:inline-block" class="form-control input-xs" type="number" ng-model = "settings.scale.y">
+          <input style="width:40px;display:inline-block" class="form-control input-xs" type="number" ng-model = "math3d.settings.scale.y">
         </label>
       </div>
     </div>
@@ -70,7 +70,7 @@
       <div class="col-xs-5 col-xs-offset-7">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.axes.y.ticksVisible"/> Ticks
+            <input type="checkbox" ng-model = "math3d.settings.axes.y.ticksVisible"/> Ticks
           </label>
         </div>
       </div>
@@ -81,26 +81,26 @@
       <div class="col-xs-6">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.axes.z.visible"/> <strong>Z-axis</strong>
+            <input type="checkbox" ng-model = "math3d.settings.axes.z.visible"/> <strong>Z-axis</strong>
           </label>
         </div>
       </div>
       <div class="col-xs-6">
         <label>
-          <input type="text" class="form-control input-xs" placeholder="Add label" ng-model = "settings.axes.z.axisLabel">
+          <input type="text" class="form-control input-xs" placeholder="Add label" ng-model = "math3d.settings.axes.z.axisLabel">
         </label>
       </div>
     </div>
     <div class="row">
       <div class="col-xs-7">
-        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "settings.range.zMin">
+        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "math3d.settings.range.zMin">
         <span>≤ Z ≤</span>
-        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "settings.range.zMax">
+        <input style="width:40px;display:inline-block" class="form-control input-xs" ng-model = "math3d.settings.range.zMax">
       </div>
       <div class="col-xs-5">
         <label style="font-weight:normal">
           Scale:
-          <input style="width:40px;display:inline-block" class="form-control input-xs" type="number" ng-model = "settings.scale.z">
+          <input style="width:40px;display:inline-block" class="form-control input-xs" type="number" ng-model = "math3d.settings.scale.z">
         </label>
       </div>
     </div>
@@ -108,7 +108,7 @@
       <div class="col-xs-5 col-xs-offset-7">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.axes.z.ticksVisible"/> Ticks
+            <input type="checkbox" ng-model = "math3d.settings.axes.z.ticksVisible"/> Ticks
           </label>
         </div>
       </div>
@@ -120,21 +120,21 @@
       <div class="col-xs-4">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.grids.xy"/> XY
+            <input type="checkbox" ng-model = "math3d.settings.grids.xy"/> XY
           </label>
         </div>
       </div>
       <div class="col-xs-4">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.grids.yz" /> YZ
+            <input type="checkbox" ng-model = "math3d.settings.grids.yz" /> YZ
           </label>
         </div>
       </div>
       <div class="col-xs-4">
         <div class="checkbox" style="margin:0pt">
           <label>
-            <input type="checkbox" ng-model = "settings.grids.xz"/> ZX
+            <input type="checkbox" ng-model = "math3d.settings.grids.xz"/> ZX
           </label>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,7 +80,7 @@
           <span class="navbar-brand" href="#">Math3d</span>
           <form class="navbar-form navbar-left navbar-title" ng-controller="settingsCtrl">
             <div class="form-group">
-              <input type="text" class="form-control input-quiet input-xs" ng-model="settings.title" style="width:[[settings.title.length+2]]ch;">
+              <input type="text" class="form-control input-quiet input-xs" ng-model="math3d.settings.title" style="width:[[math3d.settings.title.length+2]]ch;">
             </div>
           </form>
         </div>


### PR DESCRIPTION
Because math3d.settings is reassigning during a load() operation