### PR TITLE
Implement #61 (Object Insertion Point)

### DIFF
--- a/static/resources/math3d.js
+++ b/static/resources/math3d.js
@@ -983,6 +983,22 @@ class MathObject {
         this.math3d.mathTree[branchIdx].objects.splice(objIdx, 1);
     }
 
+    // Return the position of the MathObject in mathTree in a format used by the
+    // MathObject constructor for inserting after the selected item.
+    getMathtreePosition() {
+        for (let i = 0; i < math3d.mathTree.length; i++) {
+            let branch = math3d.mathTree[i].objects;
+            for (let j = 0; j < branch.length; j++) {
+                if (branch[j] === this) {
+                    return {
+                        folderIdx: i,
+                        afterPosition: j,
+                    }
+                }
+            }
+        }
+    }
+
     static renderNewObject(math3d, metaObj, insertionPoint) {
         if (metaObj.type === 'MathObject') {
             return new MathObject(math3d, metaObj.settings, insertionPoint)

--- a/static/resources/math3d.js
+++ b/static/resources/math3d.js
@@ -921,7 +921,7 @@ class MathExpression {
 
 // Abstract
 class MathObject {
-    constructor(math3d, settings, folderIdx) {
+    constructor(math3d, settings, folderIdx, eleIdx) {
         /*Guidelines:
             this.settings: 
                 should only contain information intended for serialization.
@@ -935,8 +935,13 @@ class MathObject {
             folderIdx = math3d.mathTree.length - 1;
         }
 
-        // Add new objects after the index
-        math3d.mathTree[folderIdx].objects.push(this);
+        // If eleIdx doesn't exist, push to the end of the branch
+        if (eleIdx === undefined) {
+            eleIdx = math3d.mathTree[folderIdx].objects.length - 1;
+        }
+
+        // Insert new object after the selected object.
+        math3d.mathTree[folderIdx].objects.splice(eleIdx + 1, 0, this);
 
         this.type = this.constructor.name;
         
@@ -981,47 +986,47 @@ class MathObject {
         this.math3d.mathTree[branchIdx].objects.splice(objIdx, 1);
     }
 
-    static renderNewObject(math3d, metaObj, folderIdx) {
+    static renderNewObject(math3d, metaObj, folderIdx, eleIdx) {
         if (metaObj.type === 'MathObject') {
-            return new MathObject(math3d, metaObj.settings, folderIdx)
+            return new MathObject(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'Variable') {
-            return new Variable(math3d, metaObj.settings, folderIdx)
+            return new Variable(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'VariableSlider') {
-            return new VariableSlider(math3d, metaObj.settings, folderIdx)
+            return new VariableSlider(math3d, metaObj.settings, folderIdx, eleIdx)
         };
 
         if (metaObj.type === 'Point') {
-            return new Point(math3d, metaObj.settings, folderIdx)
+            return new Point(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'Line') {
-            return new Line(math3d, metaObj.settings, folderIdx)
+            return new Line(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'Vector') {
-            return new Vector(math3d, metaObj.settings, folderIdx)
+            return new Vector(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'ParametricCurve') {
-            return new ParametricCurve(math3d, metaObj.settings, folderIdx)
+            return new ParametricCurve(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'ParametricSurface') {
-            return new ParametricSurface(math3d, metaObj.settings, folderIdx)
+            return new ParametricSurface(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'ExplicitSurface') {
-            return new ExplicitSurface(math3d, metaObj.settings, folderIdx)
+            return new ExplicitSurface(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'ExplicitSurfacePolar') {
-            return new ExplicitSurfacePolar(math3d, metaObj.settings, folderIdx)
+            return new ExplicitSurfacePolar(math3d, metaObj.settings, folderIdx, eleIdx)
         };
         if (metaObj.type === 'VariableToggle') {
-            return new VariableToggle(math3d, metaObj.settings, folderIdx)
+            return new VariableToggle(math3d, metaObj.settings, folderIdx, eleIdx)
         };
     }
 }
 
 class AbstractVariable extends MathObject {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
         
         this.scope = null; // to be set as math3d.mathScope or math3d.toggleScope by subclasses.
 
@@ -1090,8 +1095,8 @@ class AbstractVariable extends MathObject {
 }
 
 class Variable extends AbstractVariable {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
         this.scope = math3d.mathScope;
         
         this.parsed.expression = new MathExpression();
@@ -1199,8 +1204,8 @@ class Variable extends AbstractVariable {
 }
 
 class VariableSlider extends AbstractVariable {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
         this.scope = math3d.mathScope;
         
         this.parsed.min = new MathExpression();
@@ -1332,8 +1337,8 @@ class VariableSlider extends AbstractVariable {
 }
 
 class VariableToggle extends AbstractVariable {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
         this.scope = math3d.toggleScope;
         
         var _this = this;
@@ -1378,9 +1383,9 @@ class VariableToggle extends AbstractVariable {
 
 // All classes below are used for rendering graphics with MathBox
 class MathGraphic extends MathObject {
-    constructor(math3d, settings, folderIdx) {
+    constructor(math3d, settings, folderIdx, eleIdx) {
         //Every sublcass should define these
-        super(math3d, settings, folderIdx);
+        super(math3d, settings, folderIdx, eleIdx);
         this.mathboxGroup = null;
         this.mathboxDataType = null; // e.g., 'array'
         this.mathboxRenderTypes = null; // e.g., 'point'
@@ -1698,8 +1703,8 @@ class MathGraphic extends MathObject {
 }
 
 class Point extends MathGraphic {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
         this.mathboxDataType = 'array';
         this.mathboxRenderTypes = 'point';
 
@@ -1792,8 +1797,8 @@ class Point extends MathGraphic {
 }
 
 class AbstractCurve extends MathGraphic {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
         this.mathboxDataType = 'interval';
         this.mathboxRenderTypes = 'line';
 
@@ -1810,8 +1815,8 @@ class AbstractCurve extends MathGraphic {
 }
 
 class AbstractCurveFromData extends AbstractCurve {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
         this.mathboxDataType = 'array';
 
         this.userSettings = this.userSettings.concat([{
@@ -1863,8 +1868,8 @@ class AbstractCurveFromData extends AbstractCurve {
 }
 
 class Line extends AbstractCurveFromData {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
 
         this.settings = this.setDefaults(settings);
 
@@ -1882,8 +1887,8 @@ class Line extends AbstractCurveFromData {
 }
 
 class Vector extends AbstractCurveFromData {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
 
         var _this = this;
         Object.defineProperties(this.settings, {
@@ -1978,8 +1983,8 @@ class Vector extends AbstractCurveFromData {
 }
 
 class ParametricCurve extends AbstractCurve {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
 
         this.settings = this.setDefaults(settings);
         this.userSettings = this.userSettings.concat([{
@@ -2063,8 +2068,8 @@ class ParametricCurve extends AbstractCurve {
 }
 
 class AbstractSurface extends MathGraphic {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
         this.mathboxDataType = 'area';
         this.mathboxRenderTypes = 'surface, line';
         this.userSettings = this.userSettings.concat([{
@@ -2148,8 +2153,8 @@ class AbstractSurface extends MathGraphic {
 }
 
 class ParametricSurface extends AbstractSurface {
-    constructor(math3d, settings, folderIdx) {
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx) {
+        super(math3d, settings, folderIdx, eleIdx);
 
         var _this = this;
         Object.defineProperties(this.settings, {
@@ -2312,8 +2317,8 @@ class ParametricSurface extends AbstractSurface {
 }
 
 class ExplicitSurface extends ParametricSurface {
-    constructor(math3d, settings, folderIdx){
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx){
+        super(math3d, settings, folderIdx, eleIdx);
         
         var _this = this;
         delete this.settings.rawExpressionZ; // rawExpressionZ was previously set. Adding the getter/setter for it now messes up Utility.deepCopyValuesOnly unless we explicity delete the key.
@@ -2346,8 +2351,8 @@ class ExplicitSurface extends ParametricSurface {
 }
 
 class ExplicitSurfacePolar extends ParametricSurface {
-    constructor(math3d, settings, folderIdx){
-        super(math3d, settings, folderIdx);
+    constructor(math3d, settings, folderIdx, eleIdx){
+        super(math3d, settings, folderIdx, eleIdx);
         
         var _this = this;
         delete this.settings.rawExpressionZ;

--- a/static/resources/math3d.js
+++ b/static/resources/math3d.js
@@ -921,7 +921,7 @@ class MathExpression {
 
 // Abstract
 class MathObject {
-    constructor(math3d, settings) {
+    constructor(math3d, settings, folderIdx) {
         /*Guidelines:
             this.settings: 
                 should only contain information intended for serialization.
@@ -929,8 +929,14 @@ class MathObject {
         */
         this.math3d = math3d;
         this.id = _.uniqueId();
-        // Add new objects to newest mathTree branch
-        math3d.mathTree[math3d.mathTree.length - 1].objects.push(this);
+
+        // If folderIdx doesn't exist, push to the newest mathTree branch
+        if (folderIdx === undefined) {
+            folderIdx = math3d.mathTree.length - 1;
+        }
+
+        // Add new objects after the index
+        math3d.mathTree[folderIdx].objects.push(this);
 
         this.type = this.constructor.name;
         
@@ -975,47 +981,47 @@ class MathObject {
         this.math3d.mathTree[branchIdx].objects.splice(objIdx, 1);
     }
 
-    static renderNewObject(math3d, metaObj) {
+    static renderNewObject(math3d, metaObj, folderIdx) {
         if (metaObj.type === 'MathObject') {
-            return new MathObject(math3d, metaObj.settings)
+            return new MathObject(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'Variable') {
-            return new Variable(math3d, metaObj.settings)
+            return new Variable(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'VariableSlider') {
-            return new VariableSlider(math3d, metaObj.settings)
+            return new VariableSlider(math3d, metaObj.settings, folderIdx)
         };
 
         if (metaObj.type === 'Point') {
-            return new Point(math3d, metaObj.settings)
+            return new Point(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'Line') {
-            return new Line(math3d, metaObj.settings)
+            return new Line(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'Vector') {
-            return new Vector(math3d, metaObj.settings)
+            return new Vector(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'ParametricCurve') {
-            return new ParametricCurve(math3d, metaObj.settings)
+            return new ParametricCurve(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'ParametricSurface') {
-            return new ParametricSurface(math3d, metaObj.settings)
+            return new ParametricSurface(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'ExplicitSurface') {
-            return new ExplicitSurface(math3d, metaObj.settings)
+            return new ExplicitSurface(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'ExplicitSurfacePolar') {
-            return new ExplicitSurfacePolar(math3d, metaObj.settings)
+            return new ExplicitSurfacePolar(math3d, metaObj.settings, folderIdx)
         };
         if (metaObj.type === 'VariableToggle') {
-            return new VariableToggle(math3d, metaObj.settings)
+            return new VariableToggle(math3d, metaObj.settings, folderIdx)
         };
     }
 }
 
 class AbstractVariable extends MathObject {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
         
         this.scope = null; // to be set as math3d.mathScope or math3d.toggleScope by subclasses.
 
@@ -1084,8 +1090,8 @@ class AbstractVariable extends MathObject {
 }
 
 class Variable extends AbstractVariable {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
         this.scope = math3d.mathScope;
         
         this.parsed.expression = new MathExpression();
@@ -1193,8 +1199,8 @@ class Variable extends AbstractVariable {
 }
 
 class VariableSlider extends AbstractVariable {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
         this.scope = math3d.mathScope;
         
         this.parsed.min = new MathExpression();
@@ -1326,8 +1332,8 @@ class VariableSlider extends AbstractVariable {
 }
 
 class VariableToggle extends AbstractVariable {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
         this.scope = math3d.toggleScope;
         
         var _this = this;
@@ -1372,9 +1378,9 @@ class VariableToggle extends AbstractVariable {
 
 // All classes below are used for rendering graphics with MathBox
 class MathGraphic extends MathObject {
-    constructor(math3d, settings) {
+    constructor(math3d, settings, folderIdx) {
         //Every sublcass should define these
-        super(math3d, settings);
+        super(math3d, settings, folderIdx);
         this.mathboxGroup = null;
         this.mathboxDataType = null; // e.g., 'array'
         this.mathboxRenderTypes = null; // e.g., 'point'
@@ -1692,8 +1698,8 @@ class MathGraphic extends MathObject {
 }
 
 class Point extends MathGraphic {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
         this.mathboxDataType = 'array';
         this.mathboxRenderTypes = 'point';
 
@@ -1786,8 +1792,8 @@ class Point extends MathGraphic {
 }
 
 class AbstractCurve extends MathGraphic {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
         this.mathboxDataType = 'interval';
         this.mathboxRenderTypes = 'line';
 
@@ -1804,8 +1810,8 @@ class AbstractCurve extends MathGraphic {
 }
 
 class AbstractCurveFromData extends AbstractCurve {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
         this.mathboxDataType = 'array';
 
         this.userSettings = this.userSettings.concat([{
@@ -1857,8 +1863,8 @@ class AbstractCurveFromData extends AbstractCurve {
 }
 
 class Line extends AbstractCurveFromData {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
 
         this.settings = this.setDefaults(settings);
 
@@ -1876,8 +1882,8 @@ class Line extends AbstractCurveFromData {
 }
 
 class Vector extends AbstractCurveFromData {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
 
         var _this = this;
         Object.defineProperties(this.settings, {
@@ -1972,8 +1978,8 @@ class Vector extends AbstractCurveFromData {
 }
 
 class ParametricCurve extends AbstractCurve {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
 
         this.settings = this.setDefaults(settings);
         this.userSettings = this.userSettings.concat([{
@@ -2057,8 +2063,8 @@ class ParametricCurve extends AbstractCurve {
 }
 
 class AbstractSurface extends MathGraphic {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
         this.mathboxDataType = 'area';
         this.mathboxRenderTypes = 'surface, line';
         this.userSettings = this.userSettings.concat([{
@@ -2142,8 +2148,8 @@ class AbstractSurface extends MathGraphic {
 }
 
 class ParametricSurface extends AbstractSurface {
-    constructor(math3d, settings) {
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx) {
+        super(math3d, settings, folderIdx);
 
         var _this = this;
         Object.defineProperties(this.settings, {
@@ -2306,8 +2312,8 @@ class ParametricSurface extends AbstractSurface {
 }
 
 class ExplicitSurface extends ParametricSurface {
-    constructor(math3d, settings){
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx){
+        super(math3d, settings, folderIdx);
         
         var _this = this;
         delete this.settings.rawExpressionZ; // rawExpressionZ was previously set. Adding the getter/setter for it now messes up Utility.deepCopyValuesOnly unless we explicity delete the key.
@@ -2340,8 +2346,8 @@ class ExplicitSurface extends ParametricSurface {
 }
 
 class ExplicitSurfacePolar extends ParametricSurface {
-    constructor(math3d, settings){
-        super(math3d, settings);
+    constructor(math3d, settings, folderIdx){
+        super(math3d, settings, folderIdx);
         
         var _this = this;
         delete this.settings.rawExpressionZ;

--- a/static/resources/math3d.js
+++ b/static/resources/math3d.js
@@ -921,7 +921,7 @@ class MathExpression {
 
 // Abstract
 class MathObject {
-    constructor(math3d, settings, folderIdx, eleIdx) {
+    constructor(math3d, settings, insertionPoint) {
         /*Guidelines:
             this.settings: 
                 should only contain information intended for serialization.
@@ -930,18 +930,15 @@ class MathObject {
         this.math3d = math3d;
         this.id = _.uniqueId();
 
-        // If folderIdx doesn't exist, push to the newest mathTree branch
-        if (folderIdx === undefined) {
-            folderIdx = math3d.mathTree.length - 1;
-        }
-
-        // If eleIdx doesn't exist, push to the end of the branch
-        if (eleIdx === undefined) {
-            eleIdx = math3d.mathTree[folderIdx].objects.length - 1;
+        // If insertionPoint isn't given, push to the last mathTree branch
+        if (insertionPoint === undefined) {
+            var insertionPoint = {};
+            insertionPoint.folderIdx = math3d.mathTree.length - 1;
+            insertionPoint.afterPosition = math3d.mathTree[insertionPoint.folderIdx].objects.length - 1;
         }
 
         // Insert new object after the selected object.
-        math3d.mathTree[folderIdx].objects.splice(eleIdx + 1, 0, this);
+        math3d.mathTree[insertionPoint.folderIdx].objects.splice(insertionPoint.afterPosition + 1, 0, this);
 
         this.type = this.constructor.name;
         
@@ -986,47 +983,47 @@ class MathObject {
         this.math3d.mathTree[branchIdx].objects.splice(objIdx, 1);
     }
 
-    static renderNewObject(math3d, metaObj, folderIdx, eleIdx) {
+    static renderNewObject(math3d, metaObj, insertionPoint) {
         if (metaObj.type === 'MathObject') {
-            return new MathObject(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new MathObject(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'Variable') {
-            return new Variable(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new Variable(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'VariableSlider') {
-            return new VariableSlider(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new VariableSlider(math3d, metaObj.settings, insertionPoint)
         };
 
         if (metaObj.type === 'Point') {
-            return new Point(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new Point(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'Line') {
-            return new Line(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new Line(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'Vector') {
-            return new Vector(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new Vector(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'ParametricCurve') {
-            return new ParametricCurve(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new ParametricCurve(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'ParametricSurface') {
-            return new ParametricSurface(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new ParametricSurface(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'ExplicitSurface') {
-            return new ExplicitSurface(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new ExplicitSurface(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'ExplicitSurfacePolar') {
-            return new ExplicitSurfacePolar(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new ExplicitSurfacePolar(math3d, metaObj.settings, insertionPoint)
         };
         if (metaObj.type === 'VariableToggle') {
-            return new VariableToggle(math3d, metaObj.settings, folderIdx, eleIdx)
+            return new VariableToggle(math3d, metaObj.settings, insertionPoint)
         };
     }
 }
 
 class AbstractVariable extends MathObject {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
         
         this.scope = null; // to be set as math3d.mathScope or math3d.toggleScope by subclasses.
 
@@ -1095,8 +1092,8 @@ class AbstractVariable extends MathObject {
 }
 
 class Variable extends AbstractVariable {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
         this.scope = math3d.mathScope;
         
         this.parsed.expression = new MathExpression();
@@ -1204,8 +1201,8 @@ class Variable extends AbstractVariable {
 }
 
 class VariableSlider extends AbstractVariable {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
         this.scope = math3d.mathScope;
         
         this.parsed.min = new MathExpression();
@@ -1337,8 +1334,8 @@ class VariableSlider extends AbstractVariable {
 }
 
 class VariableToggle extends AbstractVariable {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
         this.scope = math3d.toggleScope;
         
         var _this = this;
@@ -1383,9 +1380,9 @@ class VariableToggle extends AbstractVariable {
 
 // All classes below are used for rendering graphics with MathBox
 class MathGraphic extends MathObject {
-    constructor(math3d, settings, folderIdx, eleIdx) {
+    constructor(math3d, settings, insertionPoint) {
         //Every sublcass should define these
-        super(math3d, settings, folderIdx, eleIdx);
+        super(math3d, settings, insertionPoint);
         this.mathboxGroup = null;
         this.mathboxDataType = null; // e.g., 'array'
         this.mathboxRenderTypes = null; // e.g., 'point'
@@ -1703,8 +1700,8 @@ class MathGraphic extends MathObject {
 }
 
 class Point extends MathGraphic {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
         this.mathboxDataType = 'array';
         this.mathboxRenderTypes = 'point';
 
@@ -1797,8 +1794,8 @@ class Point extends MathGraphic {
 }
 
 class AbstractCurve extends MathGraphic {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
         this.mathboxDataType = 'interval';
         this.mathboxRenderTypes = 'line';
 
@@ -1815,8 +1812,8 @@ class AbstractCurve extends MathGraphic {
 }
 
 class AbstractCurveFromData extends AbstractCurve {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
         this.mathboxDataType = 'array';
 
         this.userSettings = this.userSettings.concat([{
@@ -1868,8 +1865,8 @@ class AbstractCurveFromData extends AbstractCurve {
 }
 
 class Line extends AbstractCurveFromData {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
 
         this.settings = this.setDefaults(settings);
 
@@ -1887,8 +1884,8 @@ class Line extends AbstractCurveFromData {
 }
 
 class Vector extends AbstractCurveFromData {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
 
         var _this = this;
         Object.defineProperties(this.settings, {
@@ -1983,8 +1980,8 @@ class Vector extends AbstractCurveFromData {
 }
 
 class ParametricCurve extends AbstractCurve {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
 
         this.settings = this.setDefaults(settings);
         this.userSettings = this.userSettings.concat([{
@@ -2068,8 +2065,8 @@ class ParametricCurve extends AbstractCurve {
 }
 
 class AbstractSurface extends MathGraphic {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
         this.mathboxDataType = 'area';
         this.mathboxRenderTypes = 'surface, line';
         this.userSettings = this.userSettings.concat([{
@@ -2153,8 +2150,8 @@ class AbstractSurface extends MathGraphic {
 }
 
 class ParametricSurface extends AbstractSurface {
-    constructor(math3d, settings, folderIdx, eleIdx) {
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint) {
+        super(math3d, settings, insertionPoint);
 
         var _this = this;
         Object.defineProperties(this.settings, {
@@ -2317,8 +2314,8 @@ class ParametricSurface extends AbstractSurface {
 }
 
 class ExplicitSurface extends ParametricSurface {
-    constructor(math3d, settings, folderIdx, eleIdx){
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint){
+        super(math3d, settings, insertionPoint);
         
         var _this = this;
         delete this.settings.rawExpressionZ; // rawExpressionZ was previously set. Adding the getter/setter for it now messes up Utility.deepCopyValuesOnly unless we explicity delete the key.
@@ -2351,8 +2348,8 @@ class ExplicitSurface extends ParametricSurface {
 }
 
 class ExplicitSurfacePolar extends ParametricSurface {
-    constructor(math3d, settings, folderIdx, eleIdx){
-        super(math3d, settings, folderIdx, eleIdx);
+    constructor(math3d, settings, insertionPoint){
+        super(math3d, settings, insertionPoint);
         
         var _this = this;
         delete this.settings.rawExpressionZ;

--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -279,7 +279,7 @@ span.folder-name-editable{
     padding-left:0px;
 }
 
-.folder-selected {
+.item-selected {
     outline: none;
     border-color: #4e3fbc;
     box-shadow: 0 0 5px #4e3fbc;

--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -279,6 +279,12 @@ span.folder-name-editable{
     padding-left:0px;
 }
 
+.folder-selected {
+    outline: none;
+    border-color: #4e3fbc;
+    box-shadow: 0 0 5px #4e3fbc;
+}
+
 .has-error.has-feedback, .has-error.has-feedback:focus,
 .mq-editable-field.has-error.has-feedback,
 .mq-editable-field.mq-focused.has-error.has-feedback {

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -128,7 +128,7 @@ app.directive('onShortPress', function($timeout) {
 	};
 })
 
-app.controller('treeCtrl', function($scope)  {
+app.controller('treeCtrl', ['$scope', '$rootScope', function($scope, $rootScope)  {
     $scope.treeOptions = {
         accept: function(sourceNodeScope, destNodesScope, destIndex) {
             return sourceNodeScope.depth() - 1 === destNodesScope.depth()
@@ -166,7 +166,12 @@ app.controller('treeCtrl', function($scope)  {
         
         return failures;
     }
-});
+
+    // Select branch with a certain index
+    $scope.onSelect = function(index) {
+        $rootScope.folderIdx = index;
+    }
+}]);
 
 app.service("saveManager", function(){
     _this = this;

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -277,7 +277,7 @@ app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {
         $scope.math3d.mathTree.push({name:'Untitled', objects:[], collapsed:false});
     }
     
-    $scope.addOjbectToUi = function(obj){
+    $scope.addObjectToUi = function(obj){
         var content = `
             <div id="object-${obj.id}" ng-include="'/static/resources/templates/${obj.type.toLowerCase()}.html'">
             </div>`;

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -128,7 +128,7 @@ app.directive('onShortPress', function($timeout) {
 	};
 })
 
-app.controller('treeCtrl', ['$scope', '$rootScope', function($scope, $rootScope)  {
+app.controller('treeCtrl', ['$scope', function($scope)  {
     $scope.treeOptions = {
         accept: function(sourceNodeScope, destNodesScope, destIndex) {
             return sourceNodeScope.depth() - 1 === destNodesScope.depth()

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -268,14 +268,14 @@ app.controller('settingsCtrl', ['$scope', function($scope){
     $scope.math3d = math3d;
 }])
 
-app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {    
+app.controller('addObjectCtrl',['$scope', '$sce', '$rootScope', function($scope, $sce, $rootScope) {
     $scope.debug = arg => console.log(arg);
     
     $scope.math3d = math3d;
     
     $scope.createNewObject = function(type){
         var metaMathObj = {type:type, settings:{}};
-        var mathObj = MathObject.renderNewObject(math3d, metaMathObj);
+        var mathObj = MathObject.renderNewObject(math3d, metaMathObj, $rootScope.folderIdx);
     }
     
     $scope.createNewFolder = function(){

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -168,8 +168,13 @@ app.controller('treeCtrl', ['$scope', '$rootScope', function($scope, $rootScope)
     }
 
     // Select branch with a certain index
-    $scope.onSelect = function(index) {
+    $scope.onFolderSelect = function(index) {
         $rootScope.folderIdx = index;
+    }
+
+    // Select element with a certain index
+    $scope.onEleSelect = function(index) {
+        $rootScope.eleIdx = index;
     }
 }]);
 
@@ -275,7 +280,7 @@ app.controller('addObjectCtrl',['$scope', '$sce', '$rootScope', function($scope,
     
     $scope.createNewObject = function(type){
         var metaMathObj = {type:type, settings:{}};
-        var mathObj = MathObject.renderNewObject(math3d, metaMathObj, $rootScope.folderIdx);
+        var mathObj = MathObject.renderNewObject(math3d, metaMathObj, $rootScope.folderIdx, $rootScope.eleIdx);
     }
     
     $scope.createNewFolder = function(){

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -167,14 +167,9 @@ app.controller('treeCtrl', ['$scope', function($scope)  {
         return failures;
     }
 
-    // Select branch with a certain index
-    $scope.onFolderSelect = function(index) {
-        $rootScope.folderIdx = index;
-    }
-
-    // Select element with a certain index
-    $scope.onEleSelect = function(index) {
-        $rootScope.eleIdx = index;
+    // Attach the selected object to math3d
+    $scope.selectItem = function(item) {
+        math3d.selected = item;
     }
 }]);
 
@@ -273,14 +268,18 @@ app.controller('settingsCtrl', ['$scope', function($scope){
     $scope.math3d = math3d;
 }])
 
-app.controller('addObjectCtrl',['$scope', '$sce', '$rootScope', function($scope, $sce, $rootScope) {
+app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {
     $scope.debug = arg => console.log(arg);
     
     $scope.math3d = math3d;
     
     $scope.createNewObject = function(type){
         var metaMathObj = {type:type, settings:{}};
-        var mathObj = MathObject.renderNewObject(math3d, metaMathObj, $rootScope.folderIdx, $rootScope.eleIdx);
+
+        if (math3d.selected !== undefined) {
+            var insertionPoint = math3d.selected.getMathtreePosition();
+        }
+        var mathObj = MathObject.renderNewObject(math3d, metaMathObj, insertionPoint);
     }
     
     $scope.createNewFolder = function(){

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -276,6 +276,7 @@ app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {
             var insertionPoint = math3d.selected.getMathtreePosition();
         }
         var mathObj = MathObject.renderNewObject(math3d, metaMathObj, insertionPoint);
+        math3d.selected = mathObj;
     }
 
     $scope.createNewFolder = function(){

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -169,7 +169,7 @@ app.controller('treeCtrl', ['$scope', function($scope)  {
 
     // Attach the selected object to math3d
     $scope.selectItem = function(item) {
-        math3d.settings.selected = item;
+        math3d.selected = item;
     }
 }]);
 
@@ -276,8 +276,8 @@ app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {
     $scope.createNewObject = function(type){
         var metaMathObj = {type:type, settings:{}};
 
-        if (math3d.settings.selected !== undefined) {
-            var insertionPoint = math3d.settings.selected.getMathtreePosition();
+        if (math3d.selected !== undefined) {
+            var insertionPoint = math3d.selected.getMathtreePosition();
         }
         var mathObj = MathObject.renderNewObject(math3d, metaMathObj, insertionPoint);
     }

--- a/static/resources/math3d_app.js
+++ b/static/resources/math3d_app.js
@@ -169,7 +169,7 @@ app.controller('treeCtrl', ['$scope', function($scope)  {
 
     // Attach the selected object to math3d
     $scope.selectItem = function(item) {
-        math3d.selected = item;
+        math3d.settings.selected = item;
     }
 }]);
 
@@ -276,8 +276,8 @@ app.controller('addObjectCtrl',['$scope', '$sce', function($scope, $sce) {
     $scope.createNewObject = function(type){
         var metaMathObj = {type:type, settings:{}};
 
-        if (math3d.selected !== undefined) {
-            var insertionPoint = math3d.selected.getMathtreePosition();
+        if (math3d.settings.selected !== undefined) {
+            var insertionPoint = math3d.settings.selected.getMathtreePosition();
         }
         var mathObj = MathObject.renderNewObject(math3d, metaMathObj, insertionPoint);
     }

--- a/static/resources/templates/folder.html
+++ b/static/resources/templates/folder.html
@@ -1,4 +1,4 @@
-<div class="tree-node tree-node-content folder-container grippy-trigger">
+<div class="tree-node tree-node-content folder-container grippy-trigger" ng-click="onSelect($index)">
   <div class="folder-sidebar" ui-tree-handle>
     <span class="grippy"></span>
   </div>

--- a/static/resources/templates/folder.html
+++ b/static/resources/templates/folder.html
@@ -27,7 +27,7 @@
     </div>
     <!-- Folder items -->
     <div class="list-group folder-contents" ui-tree-nodes='' ng-class="{hidden: collapsed}" ng-model="branch.objects">
-      <div compile-template ui-tree-node class="list-group-item tree-node tree-node-content" ng-repeat="obj in branch.objects" ng-bind-html="$parent.addOjbectToUi(obj)" ng-show="obj.settings.showInUI">
+      <div compile-template ui-tree-node class="list-group-item tree-node tree-node-content" ng-repeat="obj in branch.objects" ng-bind-html="$parent.addObjectToUi(obj)" ng-show="obj.settings.showInUI">
       </div>
     </div>
   </div>

--- a/static/resources/templates/folder.html
+++ b/static/resources/templates/folder.html
@@ -1,4 +1,4 @@
-<div class="tree-node tree-node-content folder-container grippy-trigger" ng-click="onSelect($index)">
+<div class="tree-node tree-node-content folder-container grippy-trigger" ng-click="onFolderSelect($index)">
   <div class="folder-sidebar" ui-tree-handle>
     <span class="grippy"></span>
   </div>

--- a/static/resources/templates/folder.html
+++ b/static/resources/templates/folder.html
@@ -30,7 +30,7 @@
     <!-- Folder items -->
     <div class="list-group folder-contents" ui-tree-nodes='' ng-class="{hidden: collapsed}" ng-model="branch.objects">
       <div compile-template ui-tree-node class="list-group-item tree-node tree-node-content" ng-repeat="obj in branch.objects" ng-bind-html="$parent.addObjectToUi(obj)" ng-show="obj.settings.showInUI"
-      ng-click="selectItem(obj)" ng-class="{'item-selected': obj === math3d.settings.selected}">
+      ng-click="selectItem(obj)" ng-class="{'item-selected': obj === math3d.selected}">
       </div>
     </div>
   </div>

--- a/static/resources/templates/folder.html
+++ b/static/resources/templates/folder.html
@@ -4,7 +4,7 @@
   </div>
 
   <!-- Add folder-selected class if the index matches the selected folder index. -->
-  <div class="folder-main" ng-class="{'folder-selected': $index == folderIdx}">
+  <div class="folder-main">
     <!-- Folder Header -->
     <div class="folder-header">
       <div class="folder-header-left">
@@ -29,7 +29,8 @@
     </div>
     <!-- Folder items -->
     <div class="list-group folder-contents" ui-tree-nodes='' ng-class="{hidden: collapsed}" ng-model="branch.objects">
-      <div compile-template ui-tree-node class="list-group-item tree-node tree-node-content" ng-repeat="obj in branch.objects" ng-bind-html="$parent.addObjectToUi(obj)" ng-show="obj.settings.showInUI">
+      <div compile-template ui-tree-node class="list-group-item tree-node tree-node-content" ng-repeat="obj in branch.objects" ng-bind-html="$parent.addObjectToUi(obj)" ng-show="obj.settings.showInUI"
+      ng-click="onEleSelect($index)" ng-class="{'item-selected': $parent.$index == folderIdx && $index == eleIdx}">
       </div>
     </div>
   </div>

--- a/static/resources/templates/folder.html
+++ b/static/resources/templates/folder.html
@@ -2,7 +2,9 @@
   <div class="folder-sidebar" ui-tree-handle>
     <span class="grippy"></span>
   </div>
-  <div class="folder-main">
+
+  <!-- Add folder-selected class if the index matches the selected folder index. -->
+  <div class="folder-main" ng-class="{'folder-selected': $index == folderIdx}">
     <!-- Folder Header -->
     <div class="folder-header">
       <div class="folder-header-left">

--- a/static/resources/templates/folder.html
+++ b/static/resources/templates/folder.html
@@ -30,7 +30,7 @@
     <!-- Folder items -->
     <div class="list-group folder-contents" ui-tree-nodes='' ng-class="{hidden: collapsed}" ng-model="branch.objects">
       <div compile-template ui-tree-node class="list-group-item tree-node tree-node-content" ng-repeat="obj in branch.objects" ng-bind-html="$parent.addObjectToUi(obj)" ng-show="obj.settings.showInUI"
-      ng-click="selectItem(obj)" ng-class="{'item-selected': obj === math3d.selected}">
+      ng-click="selectItem(obj)" ng-class="{'item-selected': obj === math3d.settings.selected}">
       </div>
     </div>
   </div>

--- a/static/resources/templates/folder.html
+++ b/static/resources/templates/folder.html
@@ -1,4 +1,4 @@
-<div class="tree-node tree-node-content folder-container grippy-trigger" ng-click="onFolderSelect($index)">
+<div class="tree-node tree-node-content folder-container grippy-trigger">
   <div class="folder-sidebar" ui-tree-handle>
     <span class="grippy"></span>
   </div>
@@ -30,7 +30,7 @@
     <!-- Folder items -->
     <div class="list-group folder-contents" ui-tree-nodes='' ng-class="{hidden: collapsed}" ng-model="branch.objects">
       <div compile-template ui-tree-node class="list-group-item tree-node tree-node-content" ng-repeat="obj in branch.objects" ng-bind-html="$parent.addObjectToUi(obj)" ng-show="obj.settings.showInUI"
-      ng-click="onEleSelect($index)" ng-class="{'item-selected': $parent.$index == folderIdx && $index == eleIdx}">
+      ng-click="selectItem(obj)" ng-class="{'item-selected': obj === math3d.selected}">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Feature suggested in #61. I modified `MathObject` and everything that inherits from it to also take an optional `folderIdx` argument in the constructor, which is the index of the folder in `math3d.mathTree`. I also added to the folder template, `treeCtrl`, and `addObjectCtrl`, so that clicking on a folder highlights it and any new object you add will go to that folder. I'm working on making users able to insert after any object. It should be a similar process.