### PR TITLE
Fix navbar to the top

### DIFF
--- a/static/resources/math3d_app.css
+++ b/static/resources/math3d_app.css
@@ -179,6 +179,11 @@ input {
   color: #bfbfbf;
 }
 
+/*Prevent fixed navbar from covering content*/
+body {
+    padding-top: 40px;
+}
+
 /**************************************************/
 /* Main */
 /**************************************************/

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,7 +70,7 @@
 <body>
   
   <header>
-    <nav class="navbar navbar-default">
+    <nav class="navbar navbar-default navbar-fixed-top">
       <div class="container-fluid">
         <div class="navbar-header">
           <button type="button" class="navbar-toggle" style="height:25px;margin:3px;padding:3px" data-toggle="collapse" data-target="#myNavbar">


### PR DESCRIPTION
Fixes #103. The added `padding-top` for the body is to prevent the navbar from covering up part of the page. Is there a better way to do this?