### PR TITLE
Force ssl (always redirect to HTTPS)

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ from flask import (Flask, render_template, redirect, request, abort, url_for,
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from flask_wtf.csrf import CSRFProtect, generate_csrf
+from flask_sslify import SSLify
 
 app = Flask(__name__)
 
@@ -44,6 +45,10 @@ app.config.update(
 
 db = SQLAlchemy(app)
 bcrypt = Bcrypt(app)
+
+# Redirect to HTTPS if on Heroku
+if "DYNO" in os.environ:
+    sslify = SSLify(app)
 
 # Must import after db is defined, not pretty
 from models import User, Graph, Metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-Bcrypt==0.7.1
 Flask-Migrate==2.0.3
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.2
+Flask-SSLify==0.1.5
 Flask-WTF==0.14.2
 gunicorn==19.7.1
 itsdangerous==0.24


### PR DESCRIPTION
Just thought of this. It's a general best practice. Heroku comes with a free SSL certificate anyway, so we don't have to do any extra work.

It's on http://math3dstaging.herokuapp.com now.